### PR TITLE
Adding enable/autoenable functionnality and sites-available/enabled parameters for tuning

### DIFF
--- a/providers/file.rb
+++ b/providers/file.rb
@@ -8,7 +8,8 @@ action :create do
   server_name = new_resource.server_name || new_resource.name
   type = :dynamic
   proxy_pass = false
-  enabled_sites_dirpath = node['nginx']['dir'] + "/" + 
+  enabled_sites_dirpath = new_resource.enabled_sites_repo || (node['nginx']['dir'] || "") + "/sites-enabled"
+  available_sites_dirpath = new_resource.available_sites_repo || (node['nginx']['dir'] || "") + "/sites-available"
 
   if type == :dynamic
     locations.each do |name, location|
@@ -28,16 +29,18 @@ action :create do
   execute "test-nginx-conf" do
     command "nginx -t"
     action :nothing
-    notifies :restart, resources(:service => "nginx"), new_resource.reload
+    #notifies :restart, resources(:service => "nginx"), new_resource.reload
   end
 
-  link "#{node['nginx']['dir']}/sites-enabled/#{new_resource.name}" do
-    action :nothing
-    to "#{node['nginx']['dir']}/sites-available/#{new_resource.name}"
-    notifies :run, resources(:execute => "test-nginx-conf"), :immediately
+  if new_resource.auto_enable_site
+    nginx_conf_file new_resource.name do
+      action :enable
+      available_sites_repo new_resource.available_sites_repo
+      enabled_sites_repo new_resource.enabled_sites_repo
+    end
   end
 
-  template "#{node['nginx']['dir']}/sites-available/#{new_resource.name}" do
+  template "#{available_sites_dirpath}/#{new_resource.name}" do
     owner "root"
     group "root"
     mode "755"
@@ -52,30 +55,44 @@ action :create do
       :server_name => server_name,
       :type =>  type
     )
-    notifies :create, resources(:link => "#{node['nginx']['dir']}/sites-enabled/#{new_resource.name}"), :immediately
+    #notifies :create, resources(:link => "#{enabled_sites_dirpath}/#{new_resource.name}"), :immediately
   end
 
   new_resource.updated_by_last_action(true)
 end
 
 action :delete do
-  link "#{node['nginx']['dir']}/sites-enabled/#{new_resource.name}" do
+  link "#{enabled_sites_dirpath}/#{new_resource.name}" do
     action :delete
     to "#{node['nginx']['dir']}/sites-available/#{new_resource.name}"
-    notifies :restart, resources(:service => "nginx"), new_resource.reload
+    #notifies :restart, resources(:service => "nginx"), new_resource.reload
   end
 
-  template "#{node['nginx']['dir']}/sites-available/#{new_resource.name}" do
+  template "#{available_sites_dirpath}/#{new_resource.name}" do
     action :delete
   end
 
   new_resource.updated_by_last_action(true)
 end
 
+action :enable do
+  enabled_sites_dirpath = node['nginx']['dir'] + '/' + new_resource.enabled_sites_repo
+  available_sites_dirpath = node['nginx']['dir'] + '/' + new_resource.available_sites_repo
+
+  link "#{enabled_sites_dirpath}/#{new_resource.name}" do
+    action :nothing
+    to "#{available_sites_dirpath}/#{new_resource.name}"
+    notifies :run, resources(:execute => "test-nginx-conf"), :immediately
+  end
+end
+
 action :disable do
-  link "#{node['nginx']['dir']}/sites-enabled/#{new_resource.name}" do
+  enabled_sites_dirpath = node['nginx']['dir'] + '/' + new_resource.enabled_sites_repo
+  available_sites_dirpath = node['nginx']['dir'] + '/' + new_resource.available_sites_repo
+
+  link "#{enabled_sites_dirpath}/#{new_resource.name}" do
     action :delete
-    to "#{node['nginx']['dir']}/sites-available/#{new_resource.name}"
+    to "#{available_sites_dirpath}/#{new_resource.name}"
     notifies :restart, resources(:service => "nginx"), new_resource.reload
   end
 

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -13,9 +13,9 @@ attribute :root, :kind_of => [String, NilClass] # Server root
 attribute :server_name, :kind_of => [String, NilClass] # Server name if different then the name attribute.
 attribute :socket, :kind_of => [String, NilClass] # Path to socket file.
 attribute :template, :kind_of => [String, NilClass], :default => "conf.erb" # Template to use.
-attribute :available_sites_repo, :kind_of => String, :default => "sites-available" # Relative path from node[nginx][dir] to the available sites folder
-attribute :enabled_sites_repo, :kind_of => String, :default => "sites-enabled" # Relative path from node[nginx][dir] to the enabled sites folder 
-attribute :auto_enable_site, :kind_of => Boolean, :default => true
+attribute :available_sites_repo, :kind_of => String # Absolute path to the available sites folder
+attribute :enabled_sites_repo, :kind_of => String # Absolute path to the to the enabled sites folder 
+attribute :auto_enable_site, :kind_of => [TrueClass, FalseClass] , :default => true # Define if you want to link your newly created site conf from sites-availables to sites-enabled
 
 def initialize(*args)
   super


### PR DESCRIPTION
Hello !

I'm using your recipe for configuring Nginx. But my nginx server's architecture differs from the "Debian" standard with "sites-available" vhosts folder and "sites-enabled" links folder.

So in order to reuse your work, i've implemented the following behavior : 
- By default, without providing any arguments, the "debian" standard architecture will be used.
- You can selctively : 
  - Disable the "sitesenable" link auto-creation (i've added an "enable" action called within the create action into provider")
  - Provide other path to these folders.

Don't hesitate to contacty me for discussing if wanted ;-)

Good day !
