### PR TITLE
Specify precedence for values we later modify

### DIFF
--- a/providers/file.rb
+++ b/providers/file.rb
@@ -3,8 +3,8 @@ require 'yaml'
 
 action :create do
   listen = new_resource.listen || node['nginx_conf']['listen']
-  locations = node.default['nginx_conf']['locations'].to_hash.merge(new_resource.locations)
-  options = node.default['nginx_conf']['options'].to_hash.merge(new_resource.options)
+  locations = node.send(new_resource.precedence)['nginx_conf']['locations'].to_hash.merge(new_resource.locations)
+  options = node.send(new_resource.precedence)['nginx_conf']['options'].to_hash.merge(new_resource.options)
   server_name = new_resource.server_name || new_resource.name
   type = :dynamic
   proxy_pass = false

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -17,6 +17,7 @@ attribute :available_sites_repo, :kind_of => String # Absolute path to the avail
 attribute :enabled_sites_repo, :kind_of => String # Absolute path to the to the enabled sites folder 
 attribute :auto_enable_site, :kind_of => [TrueClass, FalseClass] , :default => true # Define if you want to link your newly created site conf from sites-availables to sites-enabled
 attribute :ssl, :kind_of => [Hash, NilClass], :default => nil #Allow the creation of ssl cert files.
+attribute :precedence, :kind_of => Symbol, :default => :default # Level of attribute precedence to use
 
 def initialize(*args)
   super


### PR DESCRIPTION
I believe this fixes #5, which is due to the way Chef11 handles modifying attributes.
