### PR TITLE
Remove explicit dependency on nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 Manage nginx server configuration files.
 
 
+
+
 #Requirements#
  * Chef >= 11.0
- * Nginx cookbook
+ * Nginx cookbook - As of version 2.0.0, we no longer require the nginx cookbook explicitly. You can use whatever means to install nginx. The only requirement is a Chef service resource called nginx be made available to this cookbook.
 
 
 #Attributes#
@@ -49,7 +51,7 @@ Creates a nginx configuration in the sites-available directory, tests it, symlin
     end
 
 Outputs to sites-available/mywebsite.com:
-  
+
     server {
       listen 80;
 
@@ -64,14 +66,14 @@ Outputs to sites-available/mywebsite.com:
     }
 
 Creating a static conf is even easier.
-  
+
     nginx_conf_file "mywebsite.com" do
       root "/var/www/myapp"
       site_type :static
     end
 
 Outputs to sites-available/mywebsite.com:
-    
+
     server {
       listen 80;
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,8 +6,6 @@ description 'Installs/Configures nginx_conf'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.0.1'
 
-depends 'nginx'
-
 %w(ubuntu debian centos redhat amazon scientific oracle fedora).each do |os|
   supports os
 end

--- a/spec/cookbooks/fake/metadata.rb
+++ b/spec/cookbooks/fake/metadata.rb
@@ -7,3 +7,4 @@ long_description 'A sample cookbook for testing the nginx_conf LWRP'
 version '0.0.1'
 
 depends 'nginx_conf'
+depends 'chef_nginx'


### PR DESCRIPTION
We don't actually need to specify nginx as a dependency for this cookbook to work.  An nginx service resource must be available, but that also doesn't require the nginx cookbook.